### PR TITLE
Use multiple zinc threads.

### DIFF
--- a/buildtemplates/multiModule/pants/pants.ini
+++ b/buildtemplates/multiModule/pants/pants.ini
@@ -5,6 +5,5 @@ print_exception_stacktrace: True
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
-[goals]
-bootstrap_buildfiles: ['%(buildroot)s/BUILD']
-
+[compile.zinc]
+worker_count: 4

--- a/buildtemplates/multiModule/pants/pants.ini
+++ b/buildtemplates/multiModule/pants/pants.ini
@@ -6,4 +6,5 @@ print_exception_stacktrace: True
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [compile.zinc]
+# TODO: see https://github.com/pantsbuild/pants/issues/2681
 worker_count: 4

--- a/buildtemplates/singleModule/pants/pants.ini
+++ b/buildtemplates/singleModule/pants/pants.ini
@@ -5,5 +5,5 @@ print_exception_stacktrace: True
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
-[goals]
-bootstrap_buildfiles: ['%(buildroot)s/BUILD']
+[compile.zinc]
+worker_count: 4

--- a/buildtemplates/singleModule/pants/pants.ini
+++ b/buildtemplates/singleModule/pants/pants.ini
@@ -6,4 +6,5 @@ print_exception_stacktrace: True
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [compile.zinc]
+# TODO: see https://github.com/pantsbuild/pants/issues/2681
 worker_count: 4


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/2681: by default, pants uses one concurrent thread to invoke zinc. In practice, almost all consumers adjust this.