### PR TITLE
Cache shaded tools (zinc/junit/checkstyle)

### DIFF
--- a/buildsystems/pants/Makefile
+++ b/buildsystems/pants/Makefile
@@ -33,7 +33,9 @@ version: $(PANTS_DIR)/pants
 .PHONY: pants%
 pants%: $(CONFIGURED_BUILD_ROOT)/pants%/BUILD $(PANTS_DIR)/pants $(CONFIGURED_BUILD_ROOT)/pants%/pants.ini% $(TIME) $(REPORTS_DIR)
 	$(info ******* pants start)
-	@cd $(CONFIGURED_BUILD_ROOT)/pants$*; $(PANTS_DIR)/pants bootstrap
+	# Do one throw-away run to ensure all tools are shaded.
+	@cd $(CONFIGURED_BUILD_ROOT)/pants$*; $(PANTS_DIR)/pants test :test
+	@cd $(CONFIGURED_BUILD_ROOT)/pants$*; $(PANTS_DIR)/pants clean-all
 	cd $(CONFIGURED_BUILD_ROOT)/pants$*; $(call TIME_CMD,$@) $(PANTS_DIR)/pants test :test
 
 

--- a/buildtemplates/multiModule/pants/pants.ini
+++ b/buildtemplates/multiModule/pants/pants.ini
@@ -2,8 +2,15 @@
 pants_version: 0.0.63
 print_exception_stacktrace: True
 
+local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
+
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+
+[cache.bootstrap]
+# TODO: see https://github.com/pantsbuild/pants/issues/2683
+read_from: ["%(local_artifact_cache)s"]
+write_to: ["%(local_artifact_cache)s"]
 
 [compile.zinc]
 # TODO: see https://github.com/pantsbuild/pants/issues/2681

--- a/buildtemplates/multiModule/pants/pants.ini
+++ b/buildtemplates/multiModule/pants/pants.ini
@@ -5,6 +5,5 @@ print_exception_stacktrace: True
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
-[goals]
-bootstrap_buildfiles: ['%(buildroot)s/BUILD']
-
+[compile.zinc]
+worker_count: 4

--- a/buildtemplates/multiModule/pants/pants.ini
+++ b/buildtemplates/multiModule/pants/pants.ini
@@ -6,4 +6,5 @@ print_exception_stacktrace: True
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [compile.zinc]
+# TODO: see https://github.com/pantsbuild/pants/issues/2681
 worker_count: 4

--- a/buildtemplates/singleModule/pants/pants.ini
+++ b/buildtemplates/singleModule/pants/pants.ini
@@ -5,5 +5,5 @@ print_exception_stacktrace: True
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
-[goals]
-bootstrap_buildfiles: ['%(buildroot)s/BUILD']
+[compile.zinc]
+worker_count: 4

--- a/buildtemplates/singleModule/pants/pants.ini
+++ b/buildtemplates/singleModule/pants/pants.ini
@@ -2,8 +2,15 @@
 pants_version: 0.0.63
 print_exception_stacktrace: True
 
+local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
+
 [jvm]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+
+[cache.bootstrap]
+# TODO: see https://github.com/pantsbuild/pants/issues/2683
+read_from: ["%(local_artifact_cache)s"]
+write_to: ["%(local_artifact_cache)s"]
 
 [compile.zinc]
 # TODO: see https://github.com/pantsbuild/pants/issues/2681

--- a/buildtemplates/singleModule/pants/pants.ini
+++ b/buildtemplates/singleModule/pants/pants.ini
@@ -6,4 +6,5 @@ print_exception_stacktrace: True
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
 [compile.zinc]
+# TODO: see https://github.com/pantsbuild/pants/issues/2681
 worker_count: 4


### PR DESCRIPTION
_(this applies atop #2)_

pants natively supports shading the tools that it runs, in order to prevent tools (particularly junit/checkstyle/et-al, which do not isolate themselves) from having classpath collisions with the code that they are building. This can take a long time but is very stable, in that it only changes when the version of a tool changes.

Consumers (including the pants repo itself) generally cache these tools in a concurrency-safe way outside of the buildroot, but this is not yet done by default. See https://github.com/pantsbuild/pants/issues/2683