### PR TITLE
Fix multiple targets owning the same sources.

### DIFF
--- a/buildtemplates/multiModule/pants/subprojectPROINDEX/BUILD.tmpl
+++ b/buildtemplates/multiModule/pants/subprojectPROINDEX/BUILD.tmpl
@@ -1,45 +1,17 @@
-
-target(name='lib{{ proindex }}',
-  dependencies = [
-    ':example-lib{{ proindex }}'
-  ],
-)
-
-target(name='test{{ proindex }}',
-  dependencies = [
-    ':example-test{{ proindex }}'
-  ],
-)
-
-java_library(name='example-lib{{ proindex }}',
+java_library(name='lib{{ proindex }}',
   sources = rglobs('src/main/java/*.java'),
   resources = [
-    'subproject{{ proindex }}/src/main/resources:resources'
+    'subproject{{ proindex }}/src/main/resources'
   ],
 )
 
-resources(name='resources',
-  sources = rglobs('src/test/resources/*'),
-  dependencies = [],
-)
-
-
-java_library(name='example-test-lib{{ proindex }}',
+junit_tests(name='test{{ proindex }}',
   sources = rglobs('src/test/java/*.java'),
   resources = [
-    'subproject{{ proindex }}/src/test/resources:resources'
-    #':resources'
+    'subproject{{ proindex }}/src/test/resources'
   ],
   dependencies = [
-    ':example-lib{{ proindex }}',
-    '3rdparty:junit'
+    ':lib{{ proindex }}',
+    '3rdparty:junit',
   ],
 )
-
-
-junit_tests(name='example-test{{ proindex }}',
-  sources = rglobs('src/test/java/*.java'),
-  dependencies = [
-    ':example-test-lib{{ proindex }}'
-   ],
- )

--- a/buildtemplates/singleModule/pants/BUILD
+++ b/buildtemplates/singleModule/pants/BUILD
@@ -1,45 +1,17 @@
-
-target(name='lib',
-  dependencies = [
-    ':example-lib'
-  ],
-)
-
-target(name='test',
-  dependencies = [
-    ':example-test'
-  ],
-)
-
-java_library(name='example-lib',
+java_library(name='lib',
   sources = rglobs('src/main/java/*.java'),
   resources = [
-    'src/main/resources:resources'
+    'src/main/resources'
   ],
 )
 
-resources(name='resources',
-  sources = rglobs('src/test/resources/*'),
-  dependencies = [],
-)
-
-
-java_library(name='example-test-lib',
+junit_tests(name='test',
   sources = rglobs('src/test/java/*.java'),
+  dependencies = [
+    '3rdparty:junit',
+    ':lib',
+  ],
   resources = [
-    'src/test/resources:resources'
-    #':resources'
+    'src/test/resources'
   ],
-  dependencies = [
-    ':example-lib',
-    '3rdparty:junit'
-  ],
-)
-
-
-junit_tests(name='example-test',
-  sources = rglobs('src/test/java/*.java'),
-  dependencies = [
-    ':example-test-lib'
-   ],
  )


### PR DESCRIPTION
_(applies independently of #2 and #3)_

pants does not enforce that mutiple targets don't contain the same sources; this was originally intended to allow for maximum pragmatism in target layout (the ability to cross-compile via creating multiple targets owning the same sources, etc) but does occasionally cause issues.

In this case, the `example-test-lib` and `example-test` targets for each template both owned the same sources, and so those sources were being double compiled.

----

This pull also cleans up a bunch of unnecessary boilerplate.