### PR TITLE
Fix bazel configuration

### DIFF
--- a/buildsystems/bazel/Makefile
+++ b/buildsystems/bazel/Makefile
@@ -33,8 +33,8 @@ version: $(BAZEL_DIR)/bazel$(BAZEL_DEFAULT_VERSION)/bin/bazel
 bazel%: $(CONFIGURED_BUILD_ROOT)/bazel%/BUILD $(BAZEL_DIR)/bazel%/bin/bazel $(REPORTS_DIR)/$(TARGET_NAME).csv
 	$(info ******* bazel start)
 # fetch command has no spawn_strategy option, required on Travis CI
-	cd $(CONFIGURED_BUILD_ROOT)/bazel$*; $(BAZEL_DIR)/bazel$*/bin/bazel --bazelrc=$(BAZEL_DIR)/bazel$*/bazel.bazelrc --output_base=$(CONFIGURED_BUILD_ROOT)/bazel$*/bazel_cache fetch -- :all
-	cd $(CONFIGURED_BUILD_ROOT)/bazel$*; $(call TIME_CMD,$@) $(BAZEL_DIR)/bazel$*/bin/bazel --watchfs --bazelrc=$(BAZEL_DIR)/bazel$*/bazel.bazelrc --output_base=$(CONFIGURED_BUILD_ROOT)/bazel$*/bazel_cache test $(BAZEL_COMMAND_OPTIONS) $(BAZEL_OPTIONS) //:example_tests
+	cd $(CONFIGURED_BUILD_ROOT)/bazel$*; $(BAZEL_DIR)/bazel$*/bin/bazel --nomaster_bazelrc --bazelrc=$(BAZEL_DIR)/bazel$*/bazel.bazelrc --output_base=$(CONFIGURED_BUILD_ROOT)/bazel$*/bazel_cache fetch -- :all
+	cd $(CONFIGURED_BUILD_ROOT)/bazel$*; $(call TIME_CMD,$@) $(BAZEL_DIR)/bazel$*/bin/bazel --nomaster_bazelrc --bazelrc=$(BAZEL_DIR)/bazel$*/bazel.bazelrc --output_base=$(CONFIGURED_BUILD_ROOT)/bazel$*/bazel_cache test $(BAZEL_COMMAND_OPTIONS) $(BAZEL_OPTIONS) //:example_tests
 
 .PRECIOUS: $(BAZEL_DIR)/bazel-%-installer-linux-x86_64.sh
 $(BAZEL_DIR)/bazel-%-installer-linux-x86_64.sh:
@@ -45,7 +45,7 @@ $(BAZEL_DIR)/bazel-%-installer-linux-x86_64.sh:
 .PRECIOUS: $(BAZEL_DIR)/bazel%/bazel.bazelrc
 $(BAZEL_DIR)/bazel%/bazel.bazelrc:
 	mkdir -p $(BAZEL_DIR)/bazel$*
-	echo "build --package_path %workspace%:$(BAZEL_DIR)/bazel$*/lib/bazel/base_workspace\nfetch --package_path %workspace%:$(BAZEL_DIR)/bazel$*/lib/bazel/base_workspace\nquery --package_path %workspace%:$(BAZEL_DIR)/bazel$*/lib/bazel/base_workspace" > $(BAZEL_DIR)/bazel$*/bazel.bazelrc
+	echo "startup --watchfs" > $(BAZEL_DIR)/bazel$*/bazel.bazelrc
 
 .PRECIOUS: $(BAZEL_DIR)/bazel%/bin/bazel
 $(BAZEL_DIR)/bazel%/bin/bazel: $(BAZEL_DIR)/bazel-%-installer-linux-x86_64.sh $(BAZEL_DIR)/bazel%/bazel.bazelrc


### PR DESCRIPTION
  - Set watchfs in the rc file to avoid server restart
    (note than with 0.4.5 it can be set as non-startup option,
    but keep it as startup option to stay compatible with
    earlier version).
  - Add --nomaster_bazelrc to avoid having a RC file from
    the host system compromise options.
  - Remove --package_path for long time unused.